### PR TITLE
Fix the mouse cursor flicker exhibited when entering reader mode

### DIFF
--- a/AngelLoader/CustomControls/RichTextBoxCustom.cs
+++ b/AngelLoader/CustomControls/RichTextBoxCustom.cs
@@ -445,14 +445,17 @@ namespace AngelLoader.CustomControls
                 case InteropMisc.WM_MBUTTONDOWN:
                     this.SetStyle(ControlStyles.Selectable, false);
                     DefWndProc(ref m);
+                    this.SetStyle(ControlStyles.Selectable, true);
                     break;
                 case InteropMisc.WM_MBUTTONUP:
                     this.SetStyle(ControlStyles.Selectable, false);
                     DefWndProc(ref m);
+                    this.SetStyle(ControlStyles.Selectable, true);
                     break;
                 case InteropMisc.WM_MBUTTONDBLCLK:
                     this.SetStyle(ControlStyles.Selectable, false);
                     DefWndProc(ref m);
+                    this.SetStyle(ControlStyles.Selectable, true);
                     break;
                 // The below DefWndProc() call essentially "calls" this section, and this section "returns" whether
                 // the cursor was over a link (via LinkCursor)

--- a/AngelLoader/CustomControls/RichTextBoxCustom.cs
+++ b/AngelLoader/CustomControls/RichTextBoxCustom.cs
@@ -437,8 +437,22 @@ namespace AngelLoader.CustomControls
         {
             switch ((uint)m.Msg)
             {
+                // Intercept the mousewheel call and direct direct it to use the fixed scrolling
                 case InteropMisc.WM_MOUSEWHEEL:
                     InterceptMousewheel(ref m);
+                    break;
+                // Fix the flickering that is present when reader mode is entered
+                case InteropMisc.WM_MBUTTONDOWN:
+                    this.SetStyle(ControlStyles.Selectable, false);
+                    DefWndProc(ref m);
+                    break;
+                case InteropMisc.WM_MBUTTONUP:
+                    this.SetStyle(ControlStyles.Selectable, false);
+                    DefWndProc(ref m);
+                    break;
+                case InteropMisc.WM_MBUTTONDBLCLK:
+                    this.SetStyle(ControlStyles.Selectable, false);
+                    DefWndProc(ref m);
                     break;
                 // The below DefWndProc() call essentially "calls" this section, and this section "returns" whether
                 // the cursor was over a link (via LinkCursor)


### PR DESCRIPTION
This was a simpler fix than expected and brief testing yields no known side effects, with the middle-mouse reader mode functionality acting intended with no visible mouse cursor flickering.