### PR TITLE
Improve RichTextBox reader mode

### DIFF
--- a/AngelLoader/CustomControls/DataGridViewCustom.cs
+++ b/AngelLoader/CustomControls/DataGridViewCustom.cs
@@ -532,6 +532,45 @@ namespace AngelLoader.CustomControls
 
         #endregion
 
+        #region Horizontal scrolling
+
+        public const int WM_MOUSEHWHEEL = 0x020E;
+
+        protected override void WndProc(ref Message m)
+        {
+            base.WndProc(ref m);
+            if (m.HWnd != Handle)
+            {
+                return;
+            }
+            else
+            {
+                if (m.Msg == WM_MOUSEHWHEEL)
+                {
+                    int delta = (int)m.WParam;
+                    if (delta < 0)
+                    {
+                        if (HorizontalScrollingOffset > 14)
+                        {
+                            HorizontalScrollingOffset -= 15;
+                        }
+                        else
+                        {
+                            HorizontalScrollingOffset = 0;
+                        }
+                        m.Result = (IntPtr)1;
+                    }
+                    if (delta > 0)
+                    {
+                        HorizontalScrollingOffset += 15;
+                        m.Result = (IntPtr)1;
+                    }
+                }
+            }
+        }
+
+        #endregion
+
         protected override void Dispose(bool disposing)
         {
             if (disposing)

--- a/AngelLoader/CustomControls/RichTextBoxCustom.cs
+++ b/AngelLoader/CustomControls/RichTextBoxCustom.cs
@@ -34,7 +34,7 @@ namespace AngelLoader.CustomControls
             _scrollInfo.fMask = (uint)ScrollInfoMask.SIF_ALL;
             ReaderModeEnabled = true;
             tmrAutoScroll = new Timer();
-            tmrAutoScroll.Interval = AUTO_SCROLL_TICK_INTERVAL;
+            tmrAutoScroll.Interval = 10;
             tmrAutoScroll.Tick += new EventHandler(tmrAutoScroll_Tick);
             pbGlyph = new PictureBox();
             pbGlyph.Size = new Size(26, 26);
@@ -401,9 +401,6 @@ namespace AngelLoader.CustomControls
 
         #region Better reader mode
 
-        const int AUTO_SCROLL_TICK_INTERVAL = 25;
-        const int AUTO_SCROLL_DISTANCE_MULTIPLIER = 2;
-
         private class NativeMethods
         {
             [DllImport("comctl32.dll", SetLastError = true, EntryPoint = "#383")]
@@ -500,7 +497,7 @@ namespace AngelLoader.CustomControls
 
         private bool ReaderScrollCallback(ref InteropTypes.READERMODEINFO prmi, int dx, int dy)
         {
-            scrollIncrementY = dy * AUTO_SCROLL_DISTANCE_MULTIPLIER;
+            scrollIncrementY = dy;
 
             if (dy != 0) endOnMouseUp = true;
 


### PR DESCRIPTION
The default RichTextBox implements the reader mode in a similar manner to its vertical scrolling, being very jumpy and treating an image the same as it does a line of text. This implementation uses the previously-added BetterScroll method to scroll the view by pixels whilst in reader mode to allow for a better and more consistent experience. This also nullifies the need for the reader mode flicker fix, as this method does not trigger this behavior.

Additionally, it is now possible to scroll the FM List DataGridView control horizontally by tilting the mouse wheel or by using other traditional methods. 