### PR TITLE
Improve RichTextBox scrolling logic

### DIFF
--- a/AngelLoader/CustomControls/RichTextBoxCustom/Workarounds.cs
+++ b/AngelLoader/CustomControls/RichTextBoxCustom/Workarounds.cs
@@ -20,6 +20,7 @@ namespace AngelLoader.CustomControls
         // No picture is used currently
         private PictureBox pbGlyph;
         private bool endOnMouseUp;
+        private int WheelAccum;
 
         #endregion
 
@@ -80,6 +81,7 @@ namespace AngelLoader.CustomControls
 
         protected override async void OnEnter(EventArgs e)
         {
+            WheelAccum = 0;
             await SetScrollPositionToCorrect();
 
             base.OnEnter(e);
@@ -144,8 +146,21 @@ namespace AngelLoader.CustomControls
                 return;
             }
 
-            int delta = (int)m.WParam;
-            if (delta != 0) BetterScroll(m.HWnd, delta < 0 ? 50 : -50);
+            int delta = 120;
+            WheelAccum += (int)m.WParam >> 16;
+            if (Math.Abs(WheelAccum) >= delta)
+            {
+                while (WheelAccum >= delta)
+                {
+                    BetterScroll(m.HWnd, -50);
+                    WheelAccum -= delta;
+                }
+                while (WheelAccum <= -delta)
+                {
+                    BetterScroll(m.HWnd, 50);
+                    WheelAccum += delta;
+                }
+            }
         }
 
         #endregion


### PR DESCRIPTION
Currently, the control only checks if the mouse wheel distance is greater or less than zero while ignoring the distance itself, which can result in the scroll procedure being sent far too frequently under some circumstances. Here, we can store the mouse wheel accumulation and increment or decrement it when the scroll procedure is sent to prevent this from happening.