### PR TITLE
Improve handling for displaying readme controls

### DIFF
--- a/AngelLoader/Forms/MainForm.cs
+++ b/AngelLoader/Forms/MainForm.cs
@@ -935,7 +935,10 @@ namespace AngelLoader.Forms
             AppMouseKeyHook.MouseMoveExt += HookMouseMove;
             AppMouseKeyHook.KeyDown += HookKeyDown;
             AppMouseKeyHook.KeyUp += HookKeyUp;
-            Application.AddMessageFilter(this);
+            // This causes some oddities on MainForm, such as wrongly highlighting the control box when
+            // hovering over certain regions of the form
+            // Disable for now
+            //Application.AddMessageFilter(this);
         }
 
         private void MainForm_Shown(object sender, EventArgs e)

--- a/AngelLoader/Forms/MainForm.cs
+++ b/AngelLoader/Forms/MainForm.cs
@@ -3866,31 +3866,6 @@ namespace AngelLoader.Forms
             ShowReadmeControls(CursorOverReadmeArea());
         }
 
-        private void ReadmeZoomInButton_MouseLeave(object sender, EventArgs e)
-        {
-            ShowReadmeControls(false);
-        }
-
-        private void ReadmeZoomOutButton_MouseLeave(object sender, EventArgs e)
-        {
-            ShowReadmeControls(false);
-        }
-
-        private void ReadmeResetZoomButton_MouseLeave(object sender, EventArgs e)
-        {
-            ShowReadmeControls(false);
-        }
-
-        private void ReadmeFullScreenButton_MouseLeave(object sender, EventArgs e)
-        {
-            ShowReadmeControls(false);
-        }
-
-        private void ChooseReadmeComboBox_MouseLeave(object sender, EventArgs e)
-        {
-            ShowReadmeControls(false);
-        }
-
         private void SetReadmeVisible(bool enabled)
         {
             ReadmeRichTextBox.Visible = enabled;

--- a/AngelLoader/Forms/MainForm.cs
+++ b/AngelLoader/Forms/MainForm.cs
@@ -575,18 +575,6 @@ namespace AngelLoader.Forms
             }
         }
 
-        private void HookMouseMove(object sender, MouseEventExtArgs e)
-        {
-            if (!CanFocus) return;
-            if (ViewBlocked)
-            {
-                e.Handled = true;
-                return;
-            }
-
-            ShowReadmeControls(CursorOverReadmeArea());
-        }
-
         private void HookKeyDown(object sender, KeyEventArgs e)
         {
             if (e.Alt && e.KeyCode == Keys.F4) return;
@@ -932,7 +920,6 @@ namespace AngelLoader.Forms
             // Hook these up last so they don't cause anything to happen while we're initializing
             AppMouseKeyHook = Hook.AppEvents();
             AppMouseKeyHook.MouseDownExt += HookMouseDown;
-            AppMouseKeyHook.MouseMoveExt += HookMouseMove;
             AppMouseKeyHook.KeyDown += HookKeyDown;
             AppMouseKeyHook.KeyUp += HookKeyUp;
             // This causes some oddities on MainForm, such as wrongly highlighting the control box when
@@ -3852,6 +3839,21 @@ namespace AngelLoader.Forms
 
         private void ReadmeRichTextBox_LinkClicked(object sender, LinkClickedEventArgs e) => Core.OpenLink(e.LinkText);
 
+        private void ReadmeRichTextBox_MouseEnter(object sender, EventArgs e)
+        {
+            ShowReadmeControls(true);
+        }
+
+        private void ReadmeRichTextBox_MouseLeave(object sender, EventArgs e)
+        {
+            if (!CursorOverControl(ReadmeZoomInButton) && !CursorOverControl(ReadmeZoomOutButton) &&
+                !CursorOverControl(ReadmeResetZoomButton) && !CursorOverControl(ReadmeFullScreenButton) &&
+                !CursorOverControl(ChooseReadmeComboBox))
+            {
+                ShowReadmeControls(false);
+            }
+        }
+
         private void ReadmeZoomInButton_Click(object sender, EventArgs e) => ReadmeRichTextBox.ZoomIn();
 
         private void ReadmeZoomOutButton_Click(object sender, EventArgs e) => ReadmeRichTextBox.ZoomOut();
@@ -3862,6 +3864,31 @@ namespace AngelLoader.Forms
         {
             MainSplitContainer.ToggleFullScreen();
             ShowReadmeControls(CursorOverReadmeArea());
+        }
+
+        private void ReadmeZoomInButton_MouseLeave(object sender, EventArgs e)
+        {
+            ShowReadmeControls(false);
+        }
+
+        private void ReadmeZoomOutButton_MouseLeave(object sender, EventArgs e)
+        {
+            ShowReadmeControls(false);
+        }
+
+        private void ReadmeResetZoomButton_MouseLeave(object sender, EventArgs e)
+        {
+            ShowReadmeControls(false);
+        }
+
+        private void ReadmeFullScreenButton_MouseLeave(object sender, EventArgs e)
+        {
+            ShowReadmeControls(false);
+        }
+
+        private void ChooseReadmeComboBox_MouseLeave(object sender, EventArgs e)
+        {
+            ShowReadmeControls(false);
         }
 
         private void SetReadmeVisible(bool enabled)

--- a/AngelLoader/Forms/MainForm.cs
+++ b/AngelLoader/Forms/MainForm.cs
@@ -588,6 +588,18 @@ namespace AngelLoader.Forms
             }
         }
 
+        private void HookMouseMove(object sender, MouseEventExtArgs e)
+        {
+            if (!CanFocus) return;
+            if (ViewBlocked)
+            {
+                e.Handled = true;
+                return;
+            }
+
+            ShowReadmeControls(CursorOverReadmeArea());
+        }
+
         private void HookKeyUp(object sender, KeyEventArgs e)
         {
             if (e.Alt && e.KeyCode == Keys.F4) return;
@@ -920,6 +932,7 @@ namespace AngelLoader.Forms
             // Hook these up last so they don't cause anything to happen while we're initializing
             AppMouseKeyHook = Hook.AppEvents();
             AppMouseKeyHook.MouseDownExt += HookMouseDown;
+            AppMouseKeyHook.MouseMoveExt += HookMouseMove;
             AppMouseKeyHook.KeyDown += HookKeyDown;
             AppMouseKeyHook.KeyUp += HookKeyUp;
             // This causes some oddities on MainForm, such as wrongly highlighting the control box when
@@ -3839,12 +3852,17 @@ namespace AngelLoader.Forms
 
         private void ReadmeRichTextBox_LinkClicked(object sender, LinkClickedEventArgs e) => Core.OpenLink(e.LinkText);
 
-        private void ReadmeRichTextBox_MouseEnter(object sender, EventArgs e)
+        private void ReadmeRichTextBox_MouseLeave(object sender, EventArgs e)
         {
-            ShowReadmeControls(true);
+            if (!CursorOverControl(ReadmeZoomInButton) && !CursorOverControl(ReadmeZoomOutButton) &&
+                !CursorOverControl(ReadmeResetZoomButton) && !CursorOverControl(ReadmeFullScreenButton) &&
+                !CursorOverControl(ChooseReadmeComboBox))
+            {
+                ShowReadmeControls(false);
+            }
         }
 
-        private void ReadmeRichTextBox_MouseLeave(object sender, EventArgs e)
+        private void Panel2_MouseLeave(object sender, EventArgs e)
         {
             if (!CursorOverControl(ReadmeZoomInButton) && !CursorOverControl(ReadmeZoomOutButton) &&
                 !CursorOverControl(ReadmeResetZoomButton) && !CursorOverControl(ReadmeFullScreenButton) &&

--- a/AngelLoader/Forms/MainForm_InitManual.cs
+++ b/AngelLoader/Forms/MainForm_InitManual.cs
@@ -1414,6 +1414,7 @@ namespace AngelLoader.Forms
             ReadmeFullScreenButton.Visible = false;
             ReadmeFullScreenButton.Click += ReadmeFullScreenButton_Click;
             ReadmeFullScreenButton.Paint += ReadmeFullScreenButton_Paint;
+            ReadmeFullScreenButton.MouseLeave += ReadmeFullScreenButton_MouseLeave;
             // 
             // ZoomInButton
             // 
@@ -1428,6 +1429,7 @@ namespace AngelLoader.Forms
             ReadmeZoomInButton.UseVisualStyleBackColor = false;
             ReadmeZoomInButton.Visible = false;
             ReadmeZoomInButton.Click += ReadmeZoomInButton_Click;
+            ReadmeZoomInButton.MouseLeave += ReadmeZoomInButton_MouseLeave;
             // 
             // ZoomOutButton
             // 
@@ -1443,6 +1445,7 @@ namespace AngelLoader.Forms
             ReadmeZoomOutButton.UseVisualStyleBackColor = false;
             ReadmeZoomOutButton.Visible = false;
             ReadmeZoomOutButton.Click += ReadmeZoomOutButton_Click;
+            ReadmeZoomOutButton.MouseLeave += ReadmeZoomOutButton_MouseLeave;
             // 
             // ResetZoomButton
             // 
@@ -1457,6 +1460,7 @@ namespace AngelLoader.Forms
             ReadmeResetZoomButton.UseVisualStyleBackColor = false;
             ReadmeResetZoomButton.Visible = false;
             ReadmeResetZoomButton.Click += ReadmeResetZoomButton_Click;
+            ReadmeResetZoomButton.MouseLeave += ReadmeResetZoomButton_MouseLeave;
 
             #endregion
             // 
@@ -1471,6 +1475,7 @@ namespace AngelLoader.Forms
             ChooseReadmeComboBox.Visible = false;
             ChooseReadmeComboBox.SelectedIndexChanged += ChooseReadmeComboBox_SelectedIndexChanged;
             ChooseReadmeComboBox.DropDownClosed += ChooseReadmeComboBox_DropDownClosed;
+            ChooseReadmeComboBox.MouseLeave += ChooseReadmeComboBox_MouseLeave;
             // 
             // ReadmeRichTextBox
             // 
@@ -1479,6 +1484,8 @@ namespace AngelLoader.Forms
             ReadmeRichTextBox.Dock = DockStyle.Fill;
             ReadmeRichTextBox.TabIndex = 0;
             ReadmeRichTextBox.LinkClicked += ReadmeRichTextBox_LinkClicked;
+            ReadmeRichTextBox.MouseEnter += ReadmeRichTextBox_MouseEnter;
+            ReadmeRichTextBox.MouseLeave += ReadmeRichTextBox_MouseLeave;
             // 
             // MainForm
             // 

--- a/AngelLoader/Forms/MainForm_InitManual.cs
+++ b/AngelLoader/Forms/MainForm_InitManual.cs
@@ -443,6 +443,11 @@ namespace AngelLoader.Forms
             FMsDGV.StandardTab = true;
             FMsDGV.TabIndex = 0;
             FMsDGV.VirtualMode = true;
+            FMsDGV.BackgroundColor = SystemColors.Control;
+            FMsDGV.EnableHeadersVisualStyles = false;
+            FMsDGV.ColumnHeadersDefaultCellStyle.SelectionBackColor = SystemColors.Menu;
+            FMsDGV.ColumnHeadersDefaultCellStyle.SelectionForeColor = SystemColors.Menu;
+            FMsDGV.ColumnHeadersDefaultCellStyle.Padding = new Padding(1);
             FMsDGV.CellDoubleClick += FMsDGV_CellDoubleClick;
             FMsDGV.CellValueNeeded += FMsDGV_CellValueNeeded_Initial;
             FMsDGV.ColumnHeaderMouseClick += FMsDGV_ColumnHeaderMouseClick;

--- a/AngelLoader/Forms/MainForm_InitManual.cs
+++ b/AngelLoader/Forms/MainForm_InitManual.cs
@@ -355,6 +355,7 @@ namespace AngelLoader.Forms
             MainSplitContainer.Size = new Size(1671, 672);
             MainSplitContainer.SplitterDistance = 309;
             MainSplitContainer.TabIndex = 0;
+            MainSplitContainer.Panel2.MouseLeave += Panel2_MouseLeave;
             // 
             // TopSplitContainer
             // 
@@ -1479,7 +1480,6 @@ namespace AngelLoader.Forms
             ReadmeRichTextBox.Dock = DockStyle.Fill;
             ReadmeRichTextBox.TabIndex = 0;
             ReadmeRichTextBox.LinkClicked += ReadmeRichTextBox_LinkClicked;
-            ReadmeRichTextBox.MouseEnter += ReadmeRichTextBox_MouseEnter;
             ReadmeRichTextBox.MouseLeave += ReadmeRichTextBox_MouseLeave;
             // 
             // MainForm

--- a/AngelLoader/Forms/MainForm_InitManual.cs
+++ b/AngelLoader/Forms/MainForm_InitManual.cs
@@ -1414,7 +1414,6 @@ namespace AngelLoader.Forms
             ReadmeFullScreenButton.Visible = false;
             ReadmeFullScreenButton.Click += ReadmeFullScreenButton_Click;
             ReadmeFullScreenButton.Paint += ReadmeFullScreenButton_Paint;
-            ReadmeFullScreenButton.MouseLeave += ReadmeFullScreenButton_MouseLeave;
             // 
             // ZoomInButton
             // 
@@ -1429,7 +1428,6 @@ namespace AngelLoader.Forms
             ReadmeZoomInButton.UseVisualStyleBackColor = false;
             ReadmeZoomInButton.Visible = false;
             ReadmeZoomInButton.Click += ReadmeZoomInButton_Click;
-            ReadmeZoomInButton.MouseLeave += ReadmeZoomInButton_MouseLeave;
             // 
             // ZoomOutButton
             // 
@@ -1445,7 +1443,6 @@ namespace AngelLoader.Forms
             ReadmeZoomOutButton.UseVisualStyleBackColor = false;
             ReadmeZoomOutButton.Visible = false;
             ReadmeZoomOutButton.Click += ReadmeZoomOutButton_Click;
-            ReadmeZoomOutButton.MouseLeave += ReadmeZoomOutButton_MouseLeave;
             // 
             // ResetZoomButton
             // 
@@ -1460,7 +1457,6 @@ namespace AngelLoader.Forms
             ReadmeResetZoomButton.UseVisualStyleBackColor = false;
             ReadmeResetZoomButton.Visible = false;
             ReadmeResetZoomButton.Click += ReadmeResetZoomButton_Click;
-            ReadmeResetZoomButton.MouseLeave += ReadmeResetZoomButton_MouseLeave;
 
             #endregion
             // 
@@ -1475,7 +1471,6 @@ namespace AngelLoader.Forms
             ChooseReadmeComboBox.Visible = false;
             ChooseReadmeComboBox.SelectedIndexChanged += ChooseReadmeComboBox_SelectedIndexChanged;
             ChooseReadmeComboBox.DropDownClosed += ChooseReadmeComboBox_DropDownClosed;
-            ChooseReadmeComboBox.MouseLeave += ChooseReadmeComboBox_MouseLeave;
             // 
             // ReadmeRichTextBox
             // 


### PR DESCRIPTION
The readme controls are currently either made visible or hidden on the MouseMove event of the control. If the cursor is located over the readme box, they are shown, and if it is not, they will be hidden; however, if another window eclipses the form and the cursor is moved directly from the readme box to this window, the controls will remain visible. Having this functionality instead governed by the MouseEnter and MouseLeave events provides better behavior in this regard and intercepts fewer events. As an aside, there is currently a bug in which the form control box buttons will highlight if the mouse is moved near the top right corner of the readme box panel while the form is maximized. The message filter seems to be the culprit of this.

Additionally, FMsDGV has been modified to be made more visually appealing. The dark gray background of the grid is a rather jarring contrast to the appearance of the rest of the form; thus, a lighter background has been set to maintain the visual pattern, though I suppose this point is rather subjective. It has also been made impossible to have the individual columns appear "selected", as this should not be possible if the only way cells can be selected is by the entire row.