### PR TITLE
Correct URL encoding to allow web searches for FMs containing &s

### DIFF
--- a/AngelLoader/Core.cs
+++ b/AngelLoader/Core.cs
@@ -1338,14 +1338,14 @@ namespace AngelLoader
             string url = Config.WebSearchUrl;
             if (url.IsWhiteSpace() || url.Length > 32766) return;
 
-            url = Uri.EscapeUriString(url);
-
-            int index = url.IndexOf("$TITLE$", StringComparison.OrdinalIgnoreCase);
-
             // Possible exceptions are:
             // ArgumentNullException (stringToEscape is null)
             // UriFormatException (The length of stringToEscape exceeds 32766 characters)
             // Those are both checked for above so we're good.
+            url = Uri.EscapeUriString(url);
+
+            int index = url.IndexOf("$TITLE$", StringComparison.OrdinalIgnoreCase);
+
             string finalUrl = index == -1
                 ? url
                 : url.Substring(0, index) + Uri.EscapeDataString(fmTitle) + url.Substring(index + "$TITLE$".Length);

--- a/AngelLoader/Core.cs
+++ b/AngelLoader/Core.cs
@@ -1338,15 +1338,17 @@ namespace AngelLoader
             string url = Config.WebSearchUrl;
             if (url.IsWhiteSpace() || url.Length > 32766) return;
 
+            url = Uri.EscapeUriString(url);
+
             int index = url.IndexOf("$TITLE$", StringComparison.OrdinalIgnoreCase);
 
             // Possible exceptions are:
             // ArgumentNullException (stringToEscape is null)
             // UriFormatException (The length of stringToEscape exceeds 32766 characters)
             // Those are both checked for above so we're good.
-            string finalUrl = Uri.EscapeUriString(index == -1
+            string finalUrl = index == -1
                 ? url
-                : url.Substring(0, index) + fmTitle + url.Substring(index + "$TITLE$".Length));
+                : url.Substring(0, index) + Uri.EscapeDataString(fmTitle) + url.Substring(index + "$TITLE$".Length);
 
             try
             {


### PR DESCRIPTION
Instead of
![old](https://user-images.githubusercontent.com/57527020/94960313-95fa4f80-04ea-11eb-9940-a4a229e8c165.png)

We now get
![new](https://user-images.githubusercontent.com/57527020/94960332-9e528a80-04ea-11eb-95f3-78a6681bbf9d.png)
