### PR TITLE
Use the encoding for the current OEM code page when reading zips

### DIFF
--- a/AngelLoader/FMBackupAndRestore.cs
+++ b/AngelLoader/FMBackupAndRestore.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
@@ -278,7 +279,7 @@ namespace AngelLoader
                 string fmInstalledPath = Path.Combine(thisFMInstallsBasePath, fm.InstalledDir);
 
                 using (var archive = new ZipArchive(new FileStream(fileToUse.Name, FileMode.Open, FileAccess.Read),
-                    ZipArchiveMode.Read, leaveOpen: false))
+                    ZipArchiveMode.Read, leaveOpen: false, Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage)))
                 {
                     int filesCount = archive.Entries.Count;
                     if (fileToUse.DarkLoader)
@@ -490,7 +491,7 @@ namespace AngelLoader
             if (fmIsZip)
             {
                 using var archive = new ZipArchive(new FileStream(fmArchivePath, FileMode.Open, FileAccess.Read),
-                    ZipArchiveMode.Read, leaveOpen: false);
+                    ZipArchiveMode.Read, leaveOpen: false, Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage));
 
                 for (int i = 0; i < archive.Entries.Count; i++)
                 {

--- a/AngelLoader/FMCache.cs
+++ b/AngelLoader/FMCache.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
+using System.Text;
 using System.Threading.Tasks;
 using AngelLoader.DataClasses;
 using AngelLoader.WinAPI;
@@ -214,7 +216,8 @@ namespace AngelLoader
             var htmlRefFiles = new List<NameAndIndex>();
 
             using var archive = new ZipArchive(new FileStream(fmArchivePath, FileMode.Open, FileAccess.Read),
-                ZipArchiveMode.Read, leaveOpen: false);
+                ZipArchiveMode.Read, leaveOpen: false,
+                Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage));
 
             foreach (string f in Directory.GetFiles(fmCachePath, "*", SearchOption.AllDirectories))
             {
@@ -300,7 +303,8 @@ namespace AngelLoader
             try
             {
                 using var archive = new ZipArchive(new FileStream(fmArchivePath, FileMode.Open, FileAccess.Read),
-                    ZipArchiveMode.Read, leaveOpen: false);
+                    ZipArchiveMode.Read, leaveOpen: false,
+                    Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage));
 
                 for (int i = 0; i < archive.Entries.Count; i++)
                 {

--- a/AngelLoader/FMInstallAndPlay.cs
+++ b/AngelLoader/FMInstallAndPlay.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Globalization;
 using System.IO;
 using System.IO.Compression;
 using System.Text;
@@ -606,7 +607,8 @@ namespace AngelLoader
                 Directory.CreateDirectory(fmInstalledPath);
 
                 using var archive = new ZipArchive(new FileStream(fmArchivePath, FileMode.Open, FileAccess.Read),
-                    ZipArchiveMode.Read, leaveOpen: false);
+                    ZipArchiveMode.Read, leaveOpen: false,
+                    Encoding.GetEncoding(CultureInfo.CurrentCulture.TextInfo.OEMCodePage));
 
                 int filesCount = archive.Entries.Count;
                 for (int i = 0; i < filesCount; i++)


### PR DESCRIPTION
When extracting zipped FM archives currently, some characters in filenames, notably non-ASCII German characters, are not recognized properly, resulting in their extracted filenames being incorrect and potentially causing problems with resource loading. For example, see the recently released Sinister Night, which has the non-ASCII 'ü' (a lowercase 'u' with an umlaut) in the filename of one of its included object models, "Rüstung.bin".

This pull request changes procedures involving zip extraction to use the encoding for the current OEM code page when reading zip entries instead of the current ANSI page, which is the default for a ZipArchive if no other encoding is specified. This change matches the behavior of 7-Zip and, consequently, other modern FM loaders. However, this should only be done when reading zip archives, not writing them. With ZipArchives, when reading archives the specified encoding is only used for entries where the language encoding flag in the general purpose bit flag of the file header is not set, while it is always used when writing archives.