### PR TITLE
fix: argument passing on >=1.28

### DIFF
--- a/AngelLoader/FMInstallAndPlay.cs
+++ b/AngelLoader/FMInstallAndPlay.cs
@@ -301,8 +301,13 @@ internal static partial class FMInstallAndPlay
 #endif
             if (!SetUsAsSelector(gameIndex, gamePath, PlaySource.OriginalGame)) return false;
 
+            // NewDark 1.28 made (undocumented) changes to how launch arguments are specified
+            var nd128 = ConfigStoredGameIsNewDark128OrAbove(gameIndex);
+
 #if !ReleaseBeta && !ReleasePublic
-            string args = Config.ForceWindowed ? "force_windowed=1" : "";
+            string args = Config.ForceWindowed
+                ? nd128 ? "-force_windowed=1"  : "force_windowed=1"
+                : "";
 #else
             string args = "";
 #endif
@@ -315,10 +320,10 @@ internal static partial class FMInstallAndPlay
                 switch (Config.GetNewMantling(gameIndex))
                 {
                     case true:
-                        args += " new_mantle=1";
+                        args += nd128 ? " -new_mantle=1" : " new_mantle=1";
                         break;
                     case false:
-                        args += " new_mantle=0";
+                        args += nd128 ? " -new_mantle=0" : " new_mantle=0";
                         break;
                 }
             }

--- a/AngelLoader/FMInstallAndPlay.cs
+++ b/AngelLoader/FMInstallAndPlay.cs
@@ -409,6 +409,8 @@ internal static partial class FMInstallAndPlay
             !steamArgs.IsEmpty() ? steamArgs :
             "-fm";
 
+        // NewDark 1.28 made (undocumented) changes to how launch arguments are specified
+        var nd128 = ConfigStoredGameIsNewDark128OrAbove(gameIndex);
         if (GameIsDark(fm.Game))
         {
             MissFlagError missFlagError = GenerateMissFlagFileIfRequired(fm, errorOnCantPlay: true);
@@ -417,7 +419,7 @@ internal static partial class FMInstallAndPlay
 #if !ReleaseBeta && !ReleasePublic
             if (Config.ForceWindowed)
             {
-                args += " force_windowed=1";
+                args += nd128 ? " -force_windowed=1" : " force_windowed=1";
             }
 #endif
 
@@ -427,7 +429,7 @@ internal static partial class FMInstallAndPlay
 
             if (fmIsOldDark && FMRequiresPaletteFix(fm, checkForOldDark: false))
             {
-                args += " legacy_32bit_txtpal=1";
+                args += nd128 ? " -legacy_32bit_txtpal=1" : " legacy_32bit_txtpal=1";
             }
 
             /*
@@ -444,33 +446,33 @@ internal static partial class FMInstallAndPlay
             */
             if (fm.NewMantle == true)
             {
-                args += " new_mantle=1";
+                args += nd128 ? " -new_mantle=1" : " new_mantle=1";
             }
             else if (fm.NewMantle == false)
             {
-                args += " new_mantle=0";
+                args += nd128 ? " -new_mantle=0" : " new_mantle=0";
             }
             else if (fmIsOldDark && Config.UseOldMantlingForOldDarkFMs)
             {
-                args += " new_mantle=0";
+                args += nd128 ? " -new_mantle=0" : " new_mantle=0";
             }
 
             if (fm.PostProc == true)
             {
-                args += " postprocess=1";
+                args += nd128 ? " -postprocess=1" : " postprocess=1";
             }
             else if (fm.PostProc == false)
             {
-                args += " postprocess=0";
+                args += nd128 ? " -postprocess=0" : " postprocess=0";
             }
 
             if (fm.NDSubs == true)
             {
-                args += " enable_subtitles=1";
+                args += nd128 ? " -enable_subtitles=1" : " enable_subtitles=1";
             }
             else if (fm.NDSubs == false)
             {
-                args += " enable_subtitles=0";
+                args += nd128 ? " -enable_subtitles=0" : " enable_subtitles=0";
             }
         }
 


### PR DESCRIPTION
Argument parsing changed on 1.28. If you tried to play an FM on a 1.28 install and had any config overrides (e.g. `new_mantle`, or implicit palette correction on some OD missions) then the FM fails to load (along with your config overrides).

I just kept these ternaries on the args inline because there's not many, but I can pull it out to be a helper method if it's preferred.